### PR TITLE
Fix for Python-2.7.5-93.0.1 upgrade

### DIFF
--- a/cob.py
+++ b/cob.py
@@ -159,7 +159,10 @@ class S3SigV4Auth(BaseSigner):
 
     def canonical_request(self, request):
         cr = [request.method.upper()]
-        path = self._normalize_url_path(urlsplit(request.url).path)
+        _path = urlsplit(request.url).path
+        if not _path.endswith('\n'):
+            _path += "\n"
+        path = self._normalize_url_path(_path)
         cr.append(path)
         headers_to_sign = self.headers_to_sign(request)
         cr.append(self.canonical_headers(headers_to_sign) + '\n')


### PR DESCRIPTION
@henrysher  - Could you review and merge this bug fix to your upstream.

**More Details:**
Add missing new line character after the repository URL. Header string needs '\n' after the end point. Without this '\n', it is causing 403 Forbidden error.

